### PR TITLE
Support custom form templates

### DIFF
--- a/c2cgeoform/__init__.py
+++ b/c2cgeoform/__init__.py
@@ -1,5 +1,6 @@
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
+from pkg_resources import resource_filename
 
 from .models import (
     DBSession,
@@ -24,19 +25,22 @@ def main(global_config, **settings):
 
     config.scan()
 
-    set_widget_template_path()
+    _set_widget_template_path()
 
     return config.make_wsgi_app()
 
 
-def set_widget_template_path():
-    from pkg_resources import resource_filename
+""" Default search paths for the form templates.
+"""
+default_search_paths = (
+    resource_filename('deform', 'templates'),
+    resource_filename('c2cgeoform', 'templates/widgets'))
+
+
+def _set_widget_template_path():
     from deform import (Form, widget)
 
-    deform_templates = resource_filename('deform', 'templates')
-    custom_templates = resource_filename('c2cgeoform', 'templates/widgets')
-    search_path = (custom_templates, deform_templates)
-    Form.set_zpt_renderer(search_path)
+    Form.set_zpt_renderer(default_search_paths)
 
     registry = widget.ResourceRegistry()
     registry.set_js_resources('json2', None, 'static/js/json2.min.js')

--- a/c2cgeoform/pully_demo.py
+++ b/c2cgeoform/pully_demo.py
@@ -2,54 +2,115 @@ from sqlalchemy import (
     Column,
     Integer,
     Text,
-    Boolean
+    Boolean,
+    Date
     )
 
 import geoalchemy2
 
 import colander
 import deform
+from pkg_resources import resource_filename
 
 from .schema import register_schema
 from .ext import colander_ext, deform_ext
 from .models import Base
+from c2cgeoform import default_search_paths
 
 
-class Person(Base):
-    __tablename__ = 'models'
+class ExcavationPermission(Base):
+    __tablename__ = 'excavations'
     __colanderalchemy_config__ = {
-        'title': 'A Person',
-        'description': 'Tell us about you.'
+        'title':
+            'Application form for permission to carry out excavation work',
+        'description':
+            'Apply to your municipal authority for permission to carry out \
+            excavation work.'
     }
 
     id = Column(Integer, primary_key=True, info={
         'colanderalchemy': {
-            'title': 'ID',
+            'title': 'Permission Number',
             'widget': deform.widget.HiddenWidget()
         }})
-    name = Column(Text, nullable=False, info={
+    referenceNumber = Column(Text, nullable=True, info={
         'colanderalchemy': {
-            'title': 'Your name'
+            'title': 'Reference Number'
         }})
-    firstName = Column(Text, nullable=False, info={
+    requestDate = Column(Date, nullable=True, info={
         'colanderalchemy': {
-            'title': 'Your first name'
+            'title': 'Request Date'
         }})
-    age = Column(Integer, info={
+
+    description = Column(Text, nullable=True, info={
         'colanderalchemy': {
-            'title': 'Your age',
-            'validator': colander.Range(18,)
+            'title': 'Description of the Work',
+            'widget': deform.widget.TextAreaWidget(rows=3),
         }})
+    motif = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'Motive for the Work',
+            'widget': deform.widget.TextAreaWidget(rows=3),
+        }})
+
+    locationStreet = Column(Text, nullable=False, info={
+        'colanderalchemy': {
+            'title': 'Street'
+        }})
+    locationPostalCode = Column(Text, nullable=False, info={
+        'colanderalchemy': {
+            'title': 'Postal Code'
+        }})
+    locationTown = Column(Text, nullable=False, info={
+        'colanderalchemy': {
+            'title': 'Town'
+        }})
+    locationPosition = Column(
+        geoalchemy2.Geometry('POINT', 4326, management=True), info={
+            'colanderalchemy': {
+                'title': 'Position',
+                'typ':
+                    colander_ext.Geometry('POINT', srid=4326, map_srid=3857),
+                'widget': deform_ext.MapWidget()
+            }})
+
+    # Person in Charge for the Work
+    responsibleName = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'Name'
+        }})
+    responsiblefFirstName = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'First Name'
+        }})
+    responsiblefMobile = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'Mobile Phone'
+        }})
+    responsiblefMail = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'Mail',
+            'validator': colander.Email()
+        }})
+    responsiblefCompany = Column(Text, nullable=True, info={
+        'colanderalchemy': {
+            'title': 'Company'
+        }})
+
     validated = Column(Boolean, info={
         'colanderalchemy': {
             'title': 'Validation',
             'label': 'Validated'
         }})
-    geom = Column(geoalchemy2.Geometry('POINT', 4326, management=True), info={
-        'colanderalchemy': {
-            'title': 'Location',
-            'typ': colander_ext.Geometry('POINT', srid=4326, map_srid=3857),
-            'widget': deform_ext.MapWidget()
-        }})
 
-register_schema('persons', Person, excludes_user=['validated'])
+
+# overwrite the form template for the user view
+pully_templates = resource_filename('c2cgeoform', 'templates/pully')
+templates_user = (pully_templates,) + default_search_paths
+
+register_schema(
+    'fouille',
+    ExcavationPermission,
+    excludes_user=['referenceNumber', 'validated'],
+    templates_user=templates_user
+    )

--- a/c2cgeoform/schema.py
+++ b/c2cgeoform/schema.py
@@ -6,7 +6,8 @@ class GeoFormSchema():
     def __init__(
             self, name, model,
             includes_user=None, excludes_user=None,
-            includes_admin=None, excludes_admin=None):
+            includes_admin=None, excludes_admin=None,
+            templates_user=None, templates_admin=None):
         self.name = name
         self.model = model
         self.schema_user = SQLAlchemySchemaNode(
@@ -15,6 +16,8 @@ class GeoFormSchema():
         self.schema_admin = SQLAlchemySchemaNode(
             self.model,
             includes=includes_admin, excludes=excludes_admin)
+        self.templates_user = templates_user
+        self.templates_admin = templates_admin
 
         meta_model = class_mapper(model)
         if len(meta_model.primary_key) != 1:
@@ -29,8 +32,10 @@ forms = {}
 def register_schema(
         name, model,
         includes_user=None, excludes_user=None,
-        includes_admin=None, excludes_admin=None):
+        includes_admin=None, excludes_admin=None,
+        templates_user=None, templates_admin=None):
     schema = GeoFormSchema(
         name, model, includes_user, excludes_user,
-        includes_admin, excludes_admin)
+        includes_admin, excludes_admin,
+        templates_user, templates_admin)
     forms[name] = schema

--- a/c2cgeoform/scripts/initializedb.py
+++ b/c2cgeoform/scripts/initializedb.py
@@ -17,7 +17,7 @@ from ..models import (
 
 # FIXME this is needed for now so the Person table is in the
 # metadata object when create_all is called.
-from ..pully_demo import Person  # flake8: noqa
+from ..pully_demo import ExcavationPermission  # flake8: noqa
 
 
 def usage(argv):
@@ -36,4 +36,5 @@ def main(argv=sys.argv):
     settings = get_appsettings(config_uri, options=options)
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
+    # Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)

--- a/c2cgeoform/templates/pully/form.pt
+++ b/c2cgeoform/templates/pully/form.pt
@@ -1,0 +1,119 @@
+<form
+  tal:define="style style|field.widget.style;
+              css_class css_class|string:${field.widget.css_class or field.css_class or ''};
+              item_template item_template|field.widget.item_template;
+              autocomplete autocomplete|field.autocomplete;
+              title title|field.title;
+              errormsg errormsg|field.errormsg;
+              description description|field.description;
+              buttons buttons|field.buttons;
+              use_ajax use_ajax|field.use_ajax;
+              ajax_options ajax_options|field.ajax_options;
+              formid formid|field.formid;
+              action action|field.action or None;
+              method method|field.method;"
+  tal:attributes="autocomplete autocomplete;
+                  style style;
+                  class css_class;
+                  action action;"
+  id="${formid}"
+  method="${method}"
+  enctype="multipart/form-data"
+  accept-charset="utf-8"
+  i18n:domain="deform"
+  >
+
+  <fieldset class="deform-form-fieldset">
+
+    <legend tal:condition="title">${title}</legend>
+
+    <input type="hidden" name="_charset_" />
+    <input type="hidden" name="__formid__" value="${formid}"/>
+
+    <div class="alert alert-danger" tal:condition="field.error">
+      <div class="error-msg-lbl" i18n:translate=""
+        >There was a problem with your submission</div>
+      <div class="error-msg-detail" i18n:translate=""
+        >Errors have been highlighted below</div>
+      <p class="error-msg">${field.errormsg}</p>
+    </div>
+
+    <p class="section first" tal:condition="description">
+      ${description}
+    </p>
+
+<!--     <div tal:repeat="child field"
+         tal:replace="structure child.render_template(item_template)"/> -->
+
+    <div tal:replace="structure field['id'].render_template(item_template)"/>
+    <div tal:replace="structure field['requestDate'].render_template(item_template)"/>
+    <div tal:replace="structure field['description'].render_template(item_template)"/>
+    <div tal:replace="structure field['motif'].render_template(item_template)"/>
+
+    <fieldset>
+      <legend>Location</legend>
+      <div tal:replace="structure field['locationStreet'].render_template(item_template)"/>
+      <div tal:replace="structure field['locationPostalCode'].render_template(item_template)"/>
+      <div tal:replace="structure field['locationTown'].render_template(item_template)"/>
+      <div tal:replace="structure field['locationPosition'].render_template(item_template)"/>
+    </fieldset>
+
+    <fieldset>
+      <legend>Person in Charge for the Work</legend>
+      <div tal:replace="structure field['responsibleName'].render_template(item_template)"/>
+      <div tal:replace="structure field['responsiblefFirstName'].render_template(item_template)"/>
+      <div tal:replace="structure field['responsiblefCompany'].render_template(item_template)"/>
+      <div tal:replace="structure field['responsiblefMobile'].render_template(item_template)"/>
+      <div tal:replace="structure field['responsiblefMail'].render_template(item_template)"/>
+    </fieldset>
+
+    <div class="form-group">
+      <tal:loop tal:repeat="button buttons">
+        <button
+              tal:define="btn_disposition repeat.button.start and 'btn-primary' or 'btn-default';
+              btn_icon button.icon|None"
+              tal:attributes="disabled button.disabled if button.disabled else None"
+              id="${formid+button.name}"
+              name="${button.name}"
+              type="${button.type}"
+              class="btn ${btn_disposition} ${button.css_class}"
+              value="${button.value}">
+          <i tal:condition="btn_icon" class="${btn_icon}"> </i>
+          ${button.title}
+        </button>
+      </tal:loop>
+    </div>
+
+  </fieldset>
+
+  <script type="text/javascript" tal:condition="use_ajax">
+   deform.addCallback(
+     '${formid}',
+     function(oid) {
+       var target = '#' + oid;
+       var options = {
+         target: target,
+         replaceTarget: true,
+         success: function() {
+           deform.processCallbacks();
+           deform.focusFirstInput(target);
+         },
+         beforeSerialize: function() { 
+           // See http://bit.ly/1agBs9Z (hack to fix tinymce-related ajax bug)
+           if ('tinymce' in window) {
+             $(tinymce.get()).each(
+               function(i, el) {
+                 var content = el.getContent();
+                 var editor_input = document.getElementById(el.id);
+                 editor_input.value = content;
+             });
+           }
+         }
+       };
+       var extra_options = ${ajax_options} || {};
+       $('#' + oid).ajaxForm($.extend(options, extra_options));
+     }
+   );
+  </script>
+
+</form>

--- a/c2cgeoform/templates/site/list.mako
+++ b/c2cgeoform/templates/site/list.mako
@@ -2,5 +2,5 @@
 
 <h3>All entities</h3>
 % for entity in entities:
-  <p>${entity.id} ${entity.name} <a href="${request.route_url('edit', schema=schema.name, id=entity.id)}">Edit</a></p>
+  <p>${entity.id} <a href="${request.route_url('edit', schema=schema.name, id=entity.id)}">Edit</a></p>
 % endfor

--- a/c2cgeoform/views.py
+++ b/c2cgeoform/views.py
@@ -1,5 +1,5 @@
 from pyramid.view import view_config
-from deform import Form, ValidationFailure
+from deform import Form, ValidationFailure, ZPTRendererFactory
 
 from .models import DBSession
 from .schema import forms
@@ -18,7 +18,9 @@ def _get_schema(request):
 def form(request):
     geo_form_schema = _get_schema(request)
 
-    form = Form(geo_form_schema.schema_user, buttons=('submit',))
+    renderer = _get_renderer(geo_form_schema.templates_user)
+    form = Form(
+        geo_form_schema.schema_user, buttons=('submit',), renderer=renderer)
 
     if 'submit' in request.POST:
         form_data = request.POST.items()
@@ -51,7 +53,10 @@ def list(request):
 @view_config(route_name='edit', renderer='templates/site/edit.mako')
 def edit(request):
     geo_form_schema = _get_schema(request)
-    form = Form(geo_form_schema.schema_admin, buttons=('submit',))
+
+    renderer = _get_renderer(geo_form_schema.templates_admin)
+    form = Form(
+        geo_form_schema.schema_admin, buttons=('submit',), renderer=renderer)
 
     if 'submit' in request.POST:
         form_data = request.POST.items()
@@ -74,3 +79,10 @@ def edit(request):
         'form': rendered,
         'schema': geo_form_schema,
         'deform_dependencies': form.get_widget_resources()}
+
+
+def _get_renderer(search_paths):
+    if search_paths is None:
+        return None
+    else:
+        return ZPTRendererFactory(search_paths)


### PR DESCRIPTION
deform does not directly allow to group form fields. As a work-around one can create two tables like in this [example](http://deform2demo.repoze.org/mapping/). But this is not really a clean solution.
The recommended way to group form fields or in general to customize the form should be to overwrite the form template.
#5
