### PR TITLE
Automatically append slash to unmatched requests

### DIFF
--- a/c2cgeoform/__init__.py
+++ b/c2cgeoform/__init__.py
@@ -18,10 +18,10 @@ def main(global_config, **settings):
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_static_view('deform_static', 'deform:static')
 
-    config.add_route('locale', '/locale')
-    config.add_route('form', '/{schema}/form')
-    config.add_route('list', '/{schema}')
-    config.add_route('edit', '/{schema}/{id}')
+    config.add_route('locale', '/locale/')
+    config.add_route('form', '/{schema}/form/')
+    config.add_route('list', '/{schema}/')
+    config.add_route('edit', '/{schema}/{id}/')
 
     config.add_translation_dirs('colander:locale', 'deform:locale', 'locale')
 

--- a/c2cgeoform/views.py
+++ b/c2cgeoform/views.py
@@ -1,4 +1,4 @@
-from pyramid.view import view_config
+from pyramid.view import view_config, notfound_view_config
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 from deform import Form, ValidationFailure, ZPTRendererFactory
@@ -17,6 +17,16 @@ def _get_schema(request):
         return forms.get(schema_name)
     else:
         raise HTTPNotFound('invalid schema \'' + schema_name + '\'')
+
+
+@notfound_view_config(append_slash=True)
+def notfound(request):
+    """ Automatically append a slash if no route can be found for a
+        request and try again.
+        This allows to make requests with ".../fouille/form/" and also
+        ".../fouille/form".
+    """
+    return HTTPNotFound()
 
 
 @view_config(route_name='form', renderer='templates/site/form.mako')


### PR DESCRIPTION
Right now, if you call http://localhost:6543/fouille/ you will get a 404. But http://localhost:6543/fouille (without a slash at the end) will work.

This PR changes the mapping, so that by default every route should be called with a slash at the end. But if the slash is not given (and no route can be matched), a slash will be appended automatically to the url.

This PR is based on #18, so #18 should be merged first.
