### PR TITLE
Replace excludes_user/includes_user with admin_only property

### DIFF
--- a/c2cgeoform/pully/model.py
+++ b/c2cgeoform/pully/model.py
@@ -35,7 +35,8 @@ class ExcavationPermission(Base):
         }})
     referenceNumber = Column(Text, nullable=True, info={
         'colanderalchemy': {
-            'title': _('Reference Number')
+            'title': _('Reference Number'),
+            'admin_only': True
         }})
     requestDate = Column(Date, nullable=True, info={
         'colanderalchemy': {
@@ -100,7 +101,8 @@ class ExcavationPermission(Base):
     validated = Column(Boolean, info={
         'colanderalchemy': {
             'title': _('Validation'),
-            'label': _('Validated')
+            'label': _('Validated'),
+            'admin_only': True
         }})
 
 
@@ -111,6 +113,5 @@ templates_user = (pully_templates,) + default_search_paths
 register_schema(
     'fouille',
     ExcavationPermission,
-    excludes_user=['referenceNumber', 'validated'],
     templates_user=templates_user
     )

--- a/c2cgeoform/tests/models_test.py
+++ b/c2cgeoform/tests/models_test.py
@@ -40,7 +40,8 @@ class Person(Base):
     validated = Column(Boolean, info={
         'colanderalchemy': {
             'title': 'Validation',
-            'label': 'Validated'
+            'label': 'Validated',
+            'admin_only': True
         }})
 
-register_schema('tests_persons', Person, excludes_user=['validated'])
+register_schema('tests_persons', Person)


### PR DESCRIPTION
So far, to hide a field in the user form, you had to write the following:

```
register_schema('tests_persons', Person, excludes_user=['validated'])
```

This PR introduces a `admin_only` property which can be directly set in the `colanderalchemy` configuration of the column:

```
class Person(Base):
        __tablename__ = 'tests_persons'
        ...
        validated = Column(Boolean, info={
            'colanderalchemy': {
                'title': 'Validation',
                'label': 'Validated',
                'admin_only': True
            }})

register_schema('tests_persons', Person)
```

With this change you can no longer hide fields in the admin form (using `excludes_admin` or `includes_admin`), but I think this is not required.

This PR also builds upon #18, so please merge #18 first.
