### PR TITLE
Use asset specifications to specify location of templates

### DIFF
--- a/c2cgeoform/__init__.py
+++ b/c2cgeoform/__init__.py
@@ -18,19 +18,19 @@ def add_routes_and_views(config):
     config.add_route('form', '/{schema}/form/')
     config.add_view('c2cgeoform.views.form',
                     route_name='form',
-                    renderer='templates/site/form.pt')
+                    renderer='c2cgeoform:templates/site/form.pt')
     config.add_route('confirm', '/{schema}/form/confirm')
     config.add_view('c2cgeoform.views.confirmation',
                     route_name='confirm',
-                    renderer='templates/site/confirmation.pt')
+                    renderer='c2cgeoform:templates/site/confirmation.pt')
     config.add_route('view_user', '/{schema}/form/{hash}')
     config.add_view('c2cgeoform.views.view_user',
                     route_name='view_user',
-                    renderer='templates/site/view_user.pt')
+                    renderer='c2cgeoform:templates/site/view_user.pt')
     config.add_route('list', '/{schema}/')
     config.add_view('c2cgeoform.views.list',
                     route_name='list',
-                    renderer='templates/site/list.pt')
+                    renderer='c2cgeoform:templates/site/list.pt')
     config.add_route('grid', '/{schema}/grid/')
     config.add_view('c2cgeoform.views.grid',
                     route_name='grid', renderer='json',
@@ -38,11 +38,11 @@ def add_routes_and_views(config):
     config.add_route('edit', '/{schema}/{id}/form')
     config.add_view('c2cgeoform.views.edit',
                     route_name='edit',
-                    renderer='templates/site/edit.pt')
+                    renderer='c2cgeoform:templates/site/edit.pt')
     config.add_route('view_admin', '/{schema}/{id}')
     config.add_view('c2cgeoform.views.view_admin',
                     route_name='view_admin',
-                    renderer='templates/site/view_admin.pt')
+                    renderer='c2cgeoform:templates/site/view_admin.pt')
 
 
 def includeme(config):


### PR DESCRIPTION
Use asset specifications instead of relative paths to specify the locations of templates in the `add_view` calls. Using relative paths does not work in an application, as the application's `templates` directory would be used instead of c2cgeoform's.
