### PR TITLE
Add support for a local settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docs/_build/
 target/
 
 .build
+locals.ini

--- a/c2cgeoform/__init__.py
+++ b/c2cgeoform/__init__.py
@@ -6,6 +6,7 @@ from pyramid.threadlocal import get_current_request
 from pyramid.events import BeforeRender, NewRequest
 
 from .models import DBSession
+from .settings import apply_local_settings
 from .subscribers import add_renderer_globals, add_localizer
 
 
@@ -109,6 +110,7 @@ def main(global_config, **settings):
     This a is test application for the model and templates defined in
     c2cgeoform/pully.
     """
+    apply_local_settings(settings)
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     config = Configurator(settings=settings)

--- a/c2cgeoform/scripts/initializedb.py
+++ b/c2cgeoform/scripts/initializedb.py
@@ -11,6 +11,7 @@ from pyramid.paster import (
 from pyramid.scripts.common import parse_vars
 
 from ..models import Base
+from ..settings import apply_local_settings
 
 
 def usage(argv):
@@ -32,6 +33,7 @@ def main(argv=sys.argv):
     options = parse_vars(argv[2:])
     setup_logging(config_uri)
     settings = get_appsettings(config_uri, options=options)
+    apply_local_settings(settings)
     engine = engine_from_config(settings, 'sqlalchemy.')
 
     # FIXME this is needed for now so the "Pully" model is in the

--- a/c2cgeoform/settings.py
+++ b/c2cgeoform/settings.py
@@ -1,0 +1,13 @@
+import os
+import ConfigParser
+
+
+def apply_local_settings(settings):
+    """ Apply to the ``settings`` dict the settings found in the local settings
+    file.
+    """
+    local_settings_path = settings.get('local_settings_path')
+    if local_settings_path is not None and os.path.exists(local_settings_path):
+        config_parser = ConfigParser.ConfigParser()
+        config_parser.read(local_settings_path)
+        settings.update(config_parser.items('app:main'))

--- a/development.ini
+++ b/development.ini
@@ -17,6 +17,7 @@ pyramid.includes =
     pyramid_tm
 
 sqlalchemy.url = postgresql://pggis:pggis@localhost:49153/pggis
+local_settings_path = %(here)s/locals.ini
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/production.ini
+++ b/production.ini
@@ -16,6 +16,7 @@ pyramid.includes =
     pyramid_tm
 
 sqlalchemy.url = postgresql://www-data:www-data@localhost/c2cgeoform
+local_settings_path = %(here)s/locals.ini
 
 [server:main]
 use = egg:waitress#main


### PR DESCRIPTION
This PR makes it possible to have a (non-committed) `locals.ini` file that overrides the settings in `development.ini`.
