### PR TITLE
Fix file upload bug

### DIFF
--- a/c2cgeoform/ext/deform_ext.py
+++ b/c2cgeoform/ext/deform_ext.py
@@ -452,10 +452,13 @@ class FileUploadWidget(DeformFileUploadWidget):
     """ Extension of ``deform.widget.FileUploadWidget`` to be used in a model
     class that extends the ``models.FileData`` mixin class.
 
-    Note: contrary to ``deform.widget.FileUploadWidget`` this extension is not
-    meant to be used with the ``deform.FileData`` Colander type. Instead it
-    works with the ``colander.Mapping`` type, which is what ``colanderalchemy``
-    uses for an SQLAlchemy model class.
+    Note that, contrary to ``deform.widget.FileUploadWidget``, this extension
+    is not meant to be used with the ``deform.FileData`` Colander type. Instead
+    it works with the ``colander.Mapping`` type, which is what
+    ``colanderalchemy`` uses for an SQLAlchemy model class.
+
+    Note also that it is required to set ``unknown`` to ``'preserve'`` in the
+    ``__colanderalchemy_config__`` dictionary.
 
     Example usage
 
@@ -468,6 +471,7 @@ class FileUploadWidget(DeformFileUploadWidget):
             __tablename__ = 'photo'
             __colanderalchemy_config__ = {
                 'title': _('Photo'),
+                'unknown': 'preserve',
                 'widget': deform_ext.FileUploadWidget(file_upload_temp_store)
             }
             permission_id = Column(Integer, ForeignKey('excavations.id'))
@@ -476,7 +480,7 @@ class FileUploadWidget(DeformFileUploadWidget):
     def serialize(self, field, cstruct, **kw):
         if cstruct in (null, None):
             cstruct = {}
-        if 'id' in cstruct:
+        if 'uid' not in cstruct and 'id' in cstruct:
             cstruct['uid'] = cstruct['id']
         return DeformFileUploadWidget.serialize(self, field, cstruct, **kw)
 

--- a/c2cgeoform/pully/model.py
+++ b/c2cgeoform/pully/model.py
@@ -70,8 +70,11 @@ class ContactPerson(Base):
 
 class Photo(FileData, Base):
     __tablename__ = 'photo'
+    # Setting unknown to 'preserve' is required in classes used as a
+    # FileUpload field.
     __colanderalchemy_config__ = {
         'title': _('Photo'),
+        'unknown': 'preserve',
         'widget': deform_ext.FileUploadWidget(_file_upload_temp_store)
     }
     permission_id = Column(Integer, ForeignKey('excavations.id'))


### PR DESCRIPTION
This fixes a bug where file upload fields are "empty" in the form when going back to the form from the confirmation page. The bug is related to the `uid` property getting lost during the validation/deserialization process. The fix involves setting "unknown" to "preserve" in the colander Mapping passed to the SchemaNode.

Requires https://github.com/stefanofontanelli/ColanderAlchemy/pull/78.