### PR TITLE
Add file link in FileUploadWidget

### DIFF
--- a/c2cgeoform/templates/widgets/readonly/file_upload.pt
+++ b/c2cgeoform/templates/widgets/readonly/file_upload.pt
@@ -1,0 +1,3 @@
+<p id="${oid|field.oid}" class="form-control-static deform-readonly-text">
+  <a href="${url}" tal:omit-tag="not:url" tal:content="cstruct.get('filename') or ''"></a>
+</p>


### PR DESCRIPTION
Permit file link in readonly FileUploadWidget (only when file is saved to the database, not in confirmation dialog).