### PR TITLE
Update NPM Openlayers and closure packages

### DIFF
--- a/c2cgeoform/scaffolds/c2cgeoform/package.json_tmpl
+++ b/c2cgeoform/scaffolds/c2cgeoform/package.json_tmpl
@@ -12,7 +12,8 @@
     "jquery": "^3.2.1",
     "jquery.scrollintoview": "1.9.4",
     "jquery-steps": "^1.1.0",
-    "openlayers": "=3.11.2",
-    "typeahead.js": "=0.10.5"
+    "openlayers": "4.5.0",
+    "typeahead.js": "=0.10.5",
+    "@camptocamp/closure-util": "1.23.0"
   }
 }


### PR DESCRIPTION
Otherwise, it does not build using nodejs on Windows. There was something wrong about OL < 4 and Windows, but I cannot remember what.

Maybe this PR is not worthwhile merging with OL 5 soon being released...