### PR TITLE
Wrong path to models

### DIFF
--- a/c2cgeoform/scaffolds/c2cgeoform/Makefile_tmpl
+++ b/c2cgeoform/scaffolds/c2cgeoform/Makefile_tmpl
@@ -46,7 +46,7 @@ test: build .build/requirements-dev.timestamp
 .PHONY: update-catalog
 update-catalog: .build/requirements.timestamp
 	.build/venv/bin/pot-create -c lingua.cfg --keyword _ -o {{package}}/locale/{{package}}.pot \
-	    {{package}}/models/{{package}}.py \
+	    {{package}}/models/ \
 	    {{package}}/views/ \
 	    {{package}}/templates/
 	msgmerge --update {{package}}/locale/fr/LC_MESSAGES/{{package}}.po {{package}}/locale/{{package}}.pot


### PR DESCRIPTION
In the makefile template, there is a lingua section which referes the Python files to be analyzed for translations.

The first one is wrong (there is no `package.py` file in the `models` folder, but rather many single Python files)