### PR TITLE
Update shapely to valid version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlalchemy==1.1.13
 geoalchemy2==0.4.0
-shapely==1.5.17.post1
+shapely==1.6.4
 pyproj==1.9.5.1
 zope.sqlalchemy==0.7.7
 psycopg2==2.7.3


### PR DESCRIPTION
Fix build

Could not find a version that satisfies the requirement shapely==1.5.17.post1 (from -r requirements.txt (line 3)) (from versions: 1.0a7, 1.0b1, 1.0b2, 1.0b3, 1.0b4, 1.0rc1, 1.0rc2, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.11, 1.0.12, 1.0.13, 1.0.14, 1.0.15, 1.2b1, 1.2b2, 1.2b3, 1.2b4, 1.2b5, 1.2b6, 1.2b7, 1.2rc1, 1.2rc2, 1.2, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.2.8, 1.2.9, 1.2.10, 1.2.12, 1.2.13, 1.2.14, 1.2.15, 1.2.16, 1.2.17, 1.2.18, 1.2.19, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.4.4, 1.5.0, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.5.5, 1.5.6, 1.5.7, 1.5.8, 1.5.9, 1.5.10, 1.5.11, 1.5.12, 1.5.13, 1.5.14, 1.5.15, 1.5.16, 1.5.17, 1.6a1, 1.6a2, 1.6b1, 1.6b2, 1.6b3, 1.6b4, 1.6b5, 1.6.0, 1.6.1, 1.6.2, 1.6.2.post1, 1.6.3, 1.6.4, 1.6.4.post1, 1.6.4.post2, 1.7a1)
No matching distribution found for shapely==1.5.17.post1 (from -r requirements.txt (line 3))