### PR TITLE
Allow application url segment customisation

### DIFF
--- a/c2cgeoform/__init__.py
+++ b/c2cgeoform/__init__.py
@@ -34,6 +34,8 @@ def includeme(config):
     """
     config.include('pyramid_chameleon')
     config.include('pyramid_beaker')  # use Beaker for session storage
+    config.include('.routes')
+    config.include('.views')
     config.add_static_view('c2cgeoform_static', 'static', cache_max_age=3600)
     config.add_static_view('deform_static', 'deform:static')
     config.add_route('locale', '/locale/')

--- a/c2cgeoform/templates/navigation.jinja2
+++ b/c2cgeoform/templates/navigation.jinja2
@@ -13,7 +13,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
-        {% for table in applications[request.matchdict.get('application', 'default')].tables() %}
+        {% for table in request.application.tables() %}
         <li role="presentation" class="{{'active' if request.matchdict and request.matchdict.get('table') == table['key'] else ''}}">
           <a href="{{request.route_url('c2cgeoform_index', table=table['key'])}}">{{request.localizer.translate(table['plural'])}}</a>
         </li>

--- a/c2cgeoform/tests/test_routes.py
+++ b/c2cgeoform/tests/test_routes.py
@@ -1,0 +1,141 @@
+# pylint: disable=no-self-use
+
+from unittest import TestCase
+
+from pyramid import testing
+from pyramid.config import Configurator
+from pyramid.exceptions import ConfigurationConflictError
+from pyramid.interfaces import IRoutesMapper
+
+from c2cgeoform.routes import (
+    Application, ApplicationRoutePredicate, register_models, register_routes,
+)
+
+
+class TestDirectives(TestCase):
+
+    def test_add_c2cgeoform_application(self):
+        config = Configurator()
+        config.include('c2cgeoform.routes')
+        config.add_c2cgeoform_application('app', models=[])
+        self.assertEqual(0, len(config.registry['c2cgeoform_applications']))
+        config.commit()
+        registered_applications = config.registry['c2cgeoform_applications']
+        self.assertEqual(1, len(registered_applications))
+        self.assertEqual('app', registered_applications[0].name())
+
+    def test_add_c2cgeoform_application_conflict(self):
+        config = Configurator()
+        config.include('c2cgeoform.routes')
+        config.add_c2cgeoform_application('app', models=[])
+        config.add_c2cgeoform_application('app', models=[])
+        with self.assertRaises(ConfigurationConflictError):
+            config.commit()
+
+
+class TestApplicationRoutePredicate(TestCase):
+
+    def _config(self, config, app_name, url_segment=None):
+        config.include('c2cgeoform.routes')
+        config.add_c2cgeoform_application(app_name, models=[], url_segment=url_segment)
+        config.commit()
+
+    def test_not_match(self):
+        with testing.testConfig() as config:
+            self._config(config, 'app')
+            pred = ApplicationRoutePredicate(config, 'anything')
+            context = {
+                'match': {
+                    'application': 'not_registered_application'
+                }
+            }
+            request = testing.DummyRequest()
+            self.assertFalse(pred(context, request))
+
+    def test_match(self):
+        with testing.testConfig() as config:
+            self._config(config, 'app')
+            pred = ApplicationRoutePredicate(config, 'anything')
+            context = {
+                'match': {
+                    'application': 'app'
+                }
+            }
+            request = testing.DummyRequest()
+            self.assertTrue(pred(context, request))
+
+            # We should have matched application in request.application
+            self.assertTrue(isinstance(request.application, Application))
+            self.assertEqual('app', request.application.name())
+
+    def test_url_segment_not_match(self):
+        with testing.testConfig() as config:
+            self._config(config, 'app', url_segment='some_segment_url')
+            pred = ApplicationRoutePredicate(config, 'anything')
+            context = {
+                'match': {
+                    'application': 'app'
+                }
+            }
+            request = testing.DummyRequest()
+            self.assertFalse(pred(context, request))
+
+    def test_url_segment_match(self):
+        with testing.testConfig() as config:
+            self._config(config, 'app', url_segment='some_segment_url')
+            pred = ApplicationRoutePredicate(config, 'anything')
+            context = {
+                'match': {
+                    'application': 'some_segment_url'
+                }
+            }
+            request = testing.DummyRequest()
+            self.assertTrue(pred(context, request))
+
+            # We should have matched application in request.application
+            self.assertTrue(isinstance(request.application, Application))
+            self.assertEqual('app', request.application.name())
+
+
+class TestPregenerator(TestCase):
+
+    def test_pregenerator(self):
+        with testing.testConfig() as config:
+            config.include('c2cgeoform.routes')
+            register_routes(config)
+            config.commit()
+            request = testing.DummyRequest()
+            request.matchdict = {
+                'application': 'app',
+                'table': 'table'
+            }
+            self.assertEqual('http://example.com/app/table', request.route_url('c2cgeoform_index'))
+
+
+class TestSingleApp(TestCase):
+
+    def test_register_models(self):
+        with testing.testConfig() as config:
+            config.include('c2cgeoform.routes')
+
+            class MyModel:
+
+                __tablename__ = 'mytable'
+
+            register_models(config, [('mytable', MyModel)])
+            register_routes(config, multi_application=False)
+
+            request = testing.DummyRequest(environ={
+                'PATH_INFO': '/mytable'
+            })
+            routes_mapper = config.registry.queryUtility(IRoutesMapper)
+            info = routes_mapper(request)
+            match, route = info['match'], info['route']
+            self.assertEqual('c2cgeoform_index', route.name)
+            self.assertEqual('mytable', match['table'])
+
+            # We should have the single application in request.application
+            self.assertTrue(isinstance(request.application, Application))
+            self.assertEqual('mytable', request.application.tables()[0]['key'])
+
+            self.assertEqual('http://example.com/table', request.route_url('c2cgeoform_index', table='table'))

--- a/c2cgeoform/views/__init__.py
+++ b/c2cgeoform/views/__init__.py
@@ -11,3 +11,54 @@ def set_locale_cookie(request):
                                     max_age=31536000)  # max_age = year
     return HTTPFound(location=request.referer,
                      headers=request.response.headers)
+
+
+class ApplicationViewPredicate(object):
+    """
+    Predicate which checks request.application.name() match with passed value.
+
+    Example usage
+
+    .. code-block:: python
+
+        @view_defaults(application='admin')
+        class AdminViews():
+    """
+    def __init__(self, application, config):  # pylint: disable=unused-argument
+        self._application = application
+
+    def text(self):
+        return 'application = %s' % (self._application,)
+
+    phash = text
+
+    def __call__(self, info, request):  # pylint: disable=unused-argument
+        return request.application.name() == self._application
+
+
+class TableViewPredicate(object):
+    """
+    Predicate which checks request.matchdict['table'] match with passed value.
+
+    Example usage
+
+    .. code-block:: python
+
+        @view_defaults(application='admin', table='users')
+        class AdminUserViews():
+    """
+    def __init__(self, table, config):  # pylint: disable=unused-argument
+        self._table = table
+
+    def text(self):
+        return 'table = %s' % (self._table,)
+
+    phash = text
+
+    def __call__(self, info, request):  # pylint: disable=unused-argument
+        return info['match']['table'] == self._table
+
+
+def includeme(config):
+    config.add_view_predicate('application', ApplicationViewPredicate)
+    config.add_view_predicate('table', TableViewPredicate)


### PR DESCRIPTION
- Register applications through configuration directive.
- Retrieve application in a route predicate and put in request.application
- Create view predicates for application and table
- Add tests