### PR TITLE
Show item actions in readonly form

### DIFF
--- a/c2cgeoform/templates/widgets/_actions.pt
+++ b/c2cgeoform/templates/widgets/_actions.pt
@@ -1,0 +1,41 @@
+<tal:loop tal:condition="exists: actions" tal:repeat="action actions">
+  <a tal:condition="not action.method()"
+     class="btn btn-default c2cgeoform-item-action ${action.name()} ${action.css_class()}"
+     href="${action.url()}">
+     <span tal:omit-tag="not action.icon()" class="${action.icon()}"></span>
+     ${action.label()}</a>
+  <a tal:condition="action.method()"
+     class="btn btn-default c2cgeoform-item-action c2cgeoform-action-ajax ${action.name()} ${action.css_class()}"
+     href="#"
+     data-url="${action.url()}"
+     data-method="${action.method()}"
+     data-confirmation="${action.confirmation()}">
+     <span tal:omit-tag="not action.icon()" class="${action.icon()}"></span>
+     ${action.label()}</a>
+</tal:loop>
+
+<script type="text/javascript">
+$(function () {
+  $('#${formid} a.c2cgeoform-action-ajax').on('click', function(e) {
+    var execute = function() {
+      $.ajax({
+        url: $(this).data('url'),
+        type: $(this).data('method'),
+        success: function(data) {
+          window.location = data.redirect;
+        }
+      });
+    }.bind(this);
+
+    if ($(this).data('confirmation')) {
+      if (window.confirm($(this).data('confirmation'))) {
+        execute();
+      }
+    } else {
+      execute();
+    }
+
+    return false;
+  });
+});
+</script>

--- a/c2cgeoform/templates/widgets/form.pt
+++ b/c2cgeoform/templates/widgets/form.pt
@@ -70,21 +70,7 @@
       </tal:loop>
 
       <div class="pull-right" i18n:domain="c2cgeoform">
-        <tal:loop tal:condition="exists: actions" tal:repeat="action actions">
-          <a tal:condition="not action.confirmation()"
-             class="btn btn-default c2cgeoform-item-action ${action.name()} ${action.css_class()}"
-             href="${action.url()}">
-             <span tal:omit-tag="not action.icon()" class="${action.icon()}"></span>
-             ${action.label()}</a>
-          <a tal:condition="action.confirmation()"
-             class="btn btn-default c2cgeoform-item-action c2cgeoform-action-ajax ${action.name()} ${action.css_class()}"
-             href="#"
-             data-url="${action.url()}"
-             data-method="${action.method()}"
-             data-confirmation="${action.confirmation()}">
-             <span tal:omit-tag="not action.icon()" class="${action.icon()}"></span>
-             ${action.label()}</a>
-        </tal:loop>
+        <tal metal:use-macro="load:_actions.pt"></tal>
       </div>
     </div>
   </div>
@@ -140,26 +126,6 @@
 $(function () {
   $('#${field.formid} button[type=submit]').click(function (e) {
     $(window).off('beforeunload')
-  });
-
-  $('a.c2cgeoform-action-ajax').on('click', function(e) {
-    var execute = function() {
-      $.ajax({
-        url: $(this).data('url'),
-        type: $(this).data('method'),
-        success: function(data) {
-          window.location = data.redirect;
-        }
-      });
-    }.bind(this);
-
-    if ($(this).data('confirmation')) {
-      if (window.confirm($(this).data('confirmation'))) {
-        execute();
-      }
-    } else {
-      execute();
-    }
   });
 });
 </script>

--- a/c2cgeoform/templates/widgets/readonly/form.pt
+++ b/c2cgeoform/templates/widgets/readonly/form.pt
@@ -39,6 +39,12 @@
       </fieldset>
 
     </div>
+
+    <div class="panel-footer clearfix" tal:condition="actions">
+      <div class="pull-right" i18n:domain="c2cgeoform">
+        <tal metal:use-macro="load:_actions.pt"></tal>
+      </div>
+    </div>
   </div>
 
 </form>

--- a/c2cgeoform/views/abstract_views.py
+++ b/c2cgeoform/views/abstract_views.py
@@ -370,7 +370,7 @@ class AbstractViews():
                 'c2cgeoform_item',
                 id=getattr(item, self._id_field))}
 
-    def _item_actions(self, item):
+    def _item_actions(self, item, readonly=False):
         actions = []
 
         if inspect(item).persistent and self._model_config().get('duplicate', False):
@@ -382,7 +382,7 @@ class AbstractViews():
                     'c2cgeoform_item_duplicate',
                     id=getattr(item, self._id_field))))
 
-        if inspect(item).persistent:
+        if inspect(item).persistent and not readonly:
             actions.append(ItemAction(
                 name='delete',
                 label=_('Delete'),
@@ -405,7 +405,7 @@ class AbstractViews():
             dict_.update(self._request.GET)
         kwargs = {
             "request": self._request,
-            "actions": self._item_actions(obj),
+            "actions": self._item_actions(obj, readonly=readonly),
             "readonly": readonly,
             "obj": obj,
         }


### PR DESCRIPTION
Needed to show "Set private" button in GetItFixed!

Note that this can be considered as a breaking change as some project might override the `_item_actions` method and does not support new `readonly parameter`. But I prefer to introduce an automated test error than a delete button in subprojects readonly forms without warning.

=> subprojects overriding `_item_actions` need to support new prototype, or use `(*args, **kwargs)` parameters.