### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,5 @@
-c2cciutils[publish]==1.3.19
-cryptography>=41.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
+c2cciutils[publish]==1.3.20
+cryptography>=42.0.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.18 # not directly required, pinned by Snyk to avoid a vulnerability
 oauthlib>=3.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade cryptography@41.0.7 to cryptography@42.0.2 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6050294] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6126975] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Use of a Broken or Risky Cryptographic Algorithm (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6149518] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ Uncontrolled Resource Consumption ('Resource Exhaustion') (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6157248] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)
    ✗ NULL Pointer Dereference (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6210214] in cryptography@41.0.7
      introduced by cryptography@41.0.7 and 2 other path(s)