### PR TITLE
Ignore CVE

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: Don't want to do a major update on a dev dependency
+        created: 2024-02-13T08:44:00.767Z
+patch: {}


### PR DESCRIPTION
    Upgrade webpack-dev-server@4.15.1 to webpack-dev-server@5.0.0 to fix
    ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
      introduced by webpack-dev-server@4.15.1 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6 and 2 other path(s)