### PR TITLE
Widen setuptools constraint to allow v83 for CVE-2026-59890

### DIFF
--- a/c2cgeoform/scaffolds/c2cgeoform/{{cookiecutter.project}}/requirements.txt
+++ b/c2cgeoform/scaffolds/c2cgeoform/{{cookiecutter.project}}/requirements.txt
@@ -7,4 +7,4 @@ pyramid_tm
 transaction
 zope.sqlalchemy
 waitress
-setuptools==80.9.0
+setuptools==83.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ shapely = "2.1.2"
 sqlalchemy = "2.0.51"
 zope-sqlalchemy = "4.1"
 requests = "2.34.2"
-setuptools = "80.10.2"
+setuptools = "83.0.0"
 
 [tool.poetry.group.dev.dependencies]
 prospector = { version = "1.19.0", extras = [
@@ -85,7 +85,7 @@ format-jinja = """
 
 [tool.poetry-plugin-tweak-dependencies-version]
 default = "present"
-setuptools = "<81.0.0"
+setuptools = "<84.0.0"
 deform = "<3.0.0"
 
 [tool.pytest.ini_options]
@@ -117,7 +117,7 @@ include = [
   "c2cgeoform/static/dist/*",
 ]
 requires-python = ">=3.12"
-dependencies = ["babel", "colanderalchemy", "deform<3.0.0", "geoalchemy2", "geojson", "lingua", "pyramid", "pyramid-beaker", "pyramid-chameleon", "pyramid-jinja2", "pyproj", "shapely", "sqlalchemy", "zope-sqlalchemy", "requests", "setuptools<81.0.0"]
+dependencies = ["babel", "colanderalchemy", "deform<3.0.0", "geoalchemy2", "geojson", "lingua", "pyramid", "pyramid-beaker", "pyramid-chameleon", "pyramid-jinja2", "pyproj", "shapely", "sqlalchemy", "zope-sqlalchemy", "requests", "setuptools<84.0.0"]
 
 [project.urls]
 repository = "https://github.com/camptocamp/c2cgeoform"


### PR DESCRIPTION
The constraint `setuptools<81.0.0` in pyproject.toml blocked Renovate PR #896 from updating setuptools to 83.0.0 (CVE-2026-59890 / GHSA-h35f-9h28-mq5c).

Widened to `<84.0.0` so the security fix can be accepted. Updated the scaffold template to match.

Closes #896

<!-- pull request links -->
See JIRA issue: [GSOO-896](https://camptocamp.atlassian.net/browse/GSOO-896).